### PR TITLE
fix(parse): reject malformed rgb input instead of emitting garbage hex

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,12 +14,15 @@ export function parseColor(color = "") {
   }
 
   if (color.includes(",")) {
-    const components = color.split(",").map((p) => Number.parseInt(p));
-    if (
-      components.length === 3 &&
-      components.every((c) => Number.isInteger(c) && c >= 0 && c <= 255)
-    ) {
-      return components;
+    // Only plain decimal integers are accepted. `Number.parseInt` would
+    // silently take a valid prefix ("1.5" -> 1, "1foo" -> 1) and `Number`
+    // would accept other numeric syntaxes ("0x10", "1e2", "" -> 0).
+    const tokens = color.split(",");
+    if (tokens.length === 3 && tokens.every((p) => /^\s*\d+\s*$/.test(p))) {
+      const components = tokens.map((p) => Number.parseInt(p, 10));
+      if (components.every((c) => c <= 255)) {
+        return components;
+      }
     }
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,7 +14,13 @@ export function parseColor(color = "") {
   }
 
   if (color.includes(",")) {
-    return color.split(",").map((p) => Number.parseInt(p));
+    const components = color.split(",").map((p) => Number.parseInt(p));
+    if (
+      components.length === 3 &&
+      components.every((c) => Number.isInteger(c) && c >= 0 && c <= 255)
+    ) {
+      return components;
+    }
   }
 
   throw new Error("Invalid color format! Use #ABC or #AABBCC or r,g,b");

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -49,6 +49,11 @@ describe("theme-colors", () => {
     ["255,0,0,0", "too many components"],
     ["300,0,0", "a component above 255"],
     ["-20,0,0", "a negative component"],
+    ["1.5,0,0", "a fractional component"],
+    ["1foo,0,0", "a component with trailing characters"],
+    ["0x10,0,0", "a hexadecimal component"],
+    ["1e2,0,0", "an exponential component"],
+    ["+1,0,0", "a signed component"],
   ])("getColors (invalid rgb: %s)", (color) => {
     expect(() => getColors(color)).toThrowError(/Invalid color format!/);
   });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -41,4 +41,15 @@ describe("theme-colors", () => {
   it("parseColor (shorthand)", () => {
     expect(parseColor("#09C")).toEqual(parseColor("#0099cc"));
   });
+
+  it.each([
+    ["a,b,c", "non-numeric components"],
+    [",,", "empty components"],
+    ["255,0", "too few components"],
+    ["255,0,0,0", "too many components"],
+    ["300,0,0", "a component above 255"],
+    ["-20,0,0", "a negative component"],
+  ])("getColors (invalid rgb: %s)", (color) => {
+    expect(() => getColors(color)).toThrowError(/Invalid color format!/);
+  });
 });


### PR DESCRIPTION
`parseColor` treats any string containing a comma as an RGB triple and maps it straight through `Number.parseInt` without checking the result. Nothing validates the count, the range, or whether the parse produced a number at all, so malformed input flows into `hexValue` and comes back out as a hex string that is not a colour:

```js
import { getColors } from "theme-colors";

getColors("a,b,c")["500"];     // '#ANANAN'   <- NaN.toString(16)
getColors(",,")["500"];        // '#ANANAN'
getColors("255,0")["500"];     // '#FF00'     <- 4 digits, not 6
getColors("255,0,0,0")["500"]; // '#FF000000' <- 8 digits
getColors("300,0,0")["500"];   // '#2C0000'   <- 300 -> 0x12C, truncated to 2C
getColors("-20,0,0")["50"];    // '#F1F2F2'   <- negative tints out of range
```

The `#ANANAN` case is the clearest: `NaN.toString(16)` is `"NaN"`, `hexValue` slices it to `"aN"`, and the result is a plausible-looking string that no CSS engine will accept. Since these values are typically spread into a Tailwind theme, the failure surfaces far from its cause — a config builds fine and the colour silently does not apply.

Hex input already rejects what it cannot parse (`getColors("#GGG")` throws), so the RGB branch is the one path that turns bad input into bad output rather than an error.

### Change

Require exactly three integers in `0–255`; anything else falls through to the existing `Invalid color format!` error. This is the same contract the error message already advertises (`Use #ABC or #AABBCC or r,g,b`), just enforced.

`Number.isInteger` covers the `NaN` case as well as fractional input like `"1.9,2,3"`, which `parseInt` silently truncated to `[1, 2, 3]` — that now throws instead of quietly changing the requested colour.

Surrounding whitespace still works (`" 171, 171,171 "`), since `parseInt` skips leading whitespace and the existing `getColors (rgb)` test covers it.

### Validation

`pnpm test` (lint + prettier + `tsc --noEmit` + vitest with coverage) passes; 11 tests, `src/` at 100% statements, branches, functions, and lines.

Added six cases to `test/index.test.ts` covering non-numeric, empty, too-few, too-many, above-range, and negative components.

### Note on compatibility

This is a behaviour change for input that currently "works": a caller passing something malformed today gets a garbage string back, and after this they get a thrown error. That seems right for a function whose other branches already throw, but happy to gate it behind an option instead if you would rather keep the loose path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid comma-separated RGB values are now rejected when they contain non-integer, signed, empty, malformed, out-of-range, or incorrectly sized components.
  - Hexadecimal, exponential, fractional, and trailing-character RGB values now report an “Invalid color format!” error.

- **Tests**
  - Added coverage for eleven malformed RGB input formats, including missing or extra components, non-numeric values, and values outside the 0–255 range.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->